### PR TITLE
Improve Draftail lite style

### DIFF
--- a/npr_poc/utils/wagtail_hooks.py
+++ b/npr_poc/utils/wagtail_hooks.py
@@ -79,7 +79,7 @@ def insert_editor_css():
         .Draftail-Toolbar {
             background-color: white !important; 
             color: #606060 !important;
-            border: 1px solid #606060;
+            border: 1px solid #606060!important;
             border-radius: 3px;
         }
         .Draftail-ToolbarGroup:before {
@@ -89,6 +89,12 @@ def insert_editor_css():
             height: 0 !important;
             vertical-align: middle;
             margin: 0 !important;
+        }
+        
+        .Draftail-ToolbarButton:hover,
+        .Draftail-ToolbarButton--active {
+            background-color: #eee!important;
+            border: 1px solid #ddd!important;
         }
     </style>"""
 


### PR DESCRIPTION
1. makes the bottom border come back 
2. highlights formatting options when they’re selected (and on hover)

![Screenshot 2019-05-15 at 17 02 13](https://user-images.githubusercontent.com/31622/57790789-5e430a00-7733-11e9-87f3-e92244051e70.png)
