### PR TITLE
Add basic write endpoint

### DIFF
--- a/npr_poc/API.md
+++ b/npr_poc/API.md
@@ -1,0 +1,28 @@
+# API
+
+See `api.py` for the available endpoints.
+
+The Wagtail API uses [Django Rest Framework](https://django-rest-framework.org) (DRF) and is read-only out of the box.
+It also has a browsable version.
+
+## Storify Endpoint
+
+The Storify endpoint is a custom, write-enabled endpoint that allows creating simple `NewsPage` objects.
+
+You can access it at `/api/storify/`.
+
+To create a new item:
+
+```bash
+curl -X POST \
+  http://npr-poc.torchbox.com/api/storify/ \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d '{
+    "title": "Foo 1",
+    "date": "2019-05-16",
+    "body": "<h2>title me this</h2><p>something</p><ul><li>one</li><li>two</li></ul>",
+    "summary": "Summary be here",
+    "author": "John Doe"
+}'
+```

--- a/npr_poc/api.py
+++ b/npr_poc/api.py
@@ -1,10 +1,18 @@
+import json
+
+from rest_framework import status, serializers
+from rest_framework.generics import ListCreateAPIView
+from rest_framework.response import Response
 from wagtail.api.v2.endpoints import PagesAPIEndpoint
 from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.api.v2.serializers import PageSerializer, StreamField
 from wagtail.documents.api.v2.endpoints import DocumentsAPIEndpoint
 from wagtail.images.api.v2.endpoints import ImagesAPIEndpoint
 
+from npr_poc.news.models import NewsPage
 from npr_poc.utils.api import PagePreviewAPIEndpoint
 from npr_poc.podcasts.api.endpoints import MediaAPIEndpoint
+from npr_poc.utils.google import html_to_stream_data
 
 api_router = WagtailAPIRouter('wagtailapi')
 
@@ -13,3 +21,55 @@ api_router.register_endpoint('images', ImagesAPIEndpoint)
 api_router.register_endpoint('documents', DocumentsAPIEndpoint)
 api_router.register_endpoint('media', MediaAPIEndpoint)
 api_router.register_endpoint('page_preview', PagePreviewAPIEndpoint)
+
+
+class FancyStreamFieldSerializer(StreamField):
+    def to_internal_value(self, data):
+        body = html_to_stream_data(data)
+        return json.dumps(body)
+
+
+class NewsPageSerializer(PageSerializer):
+    author = serializers.StringRelatedField()
+    categories = serializers.StringRelatedField()
+    body = FancyStreamFieldSerializer()
+    tags = serializers.StringRelatedField()
+
+    class Meta:
+        model = NewsPage
+        fields = ('title', 'date', 'body', 'summary', 'author', 'categories', 'tags')
+
+    meta_fields = []
+    child_serializer_classes = {}
+
+    def create(self, validated_data):
+        page = self.Meta.model(**validated_data)
+
+        return page
+
+
+class StorifyAPIEndpoint(ListCreateAPIView):
+    serializer_class = NewsPageSerializer
+    page_size = 20
+
+    def get_queryset(self):
+        return NewsPage.objects.descendant_of(self.request.site.root_page)
+
+    def post(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        data = request.data
+
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+
+        instance = serializer.save()
+        parent = self.get_parent()
+        parent.add_child(instance=instance)
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def get_parent(self):
+        return NewsPage.objects.descendant_of(self.request.site.root_page, inclusive=True).first().get_parent()

--- a/npr_poc/urls.py
+++ b/npr_poc/urls.py
@@ -16,7 +16,7 @@ from wagtail_review import urls as wagtailreview_urls
 from npr_poc.search import views as search_views
 from npr_poc.utils.cache import get_default_cache_control_decorator
 
-from .api import api_router
+from .api import api_router, StorifyAPIEndpoint
 
 # Private URLs are not meant to be cached.
 private_urlpatterns = [
@@ -86,6 +86,7 @@ urlpatterns = decorate_urlpatterns(
 urlpatterns = private_urlpatterns + urlpatterns + [
     # Add Wagtail URLs at the end.
     path('api/v2/', api_router.urls),
+    path('api/storify/', StorifyAPIEndpoint.as_view()),
     # Wagtail cache-control is set on the page models's serve methods.
     path('', include(wagtail_urls)),
 ]


### PR DESCRIPTION
adds a basic "write" endpoint for news

Currently sets the title/body/date.

Soon to handle tags/byline and category